### PR TITLE
Update interactive background to use NOIRLab All-Sky/DSS hybrid

### DIFF
--- a/public/bg.wtml
+++ b/public/bg.wtml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Folder Browseable="True" Group="Explorer" Name="JWST First Images" Searchable="True">
+  <ImageSet BandPass="Visible" BaseDegreesPerTile="180.0" BaseTileLevel="0" BottomsUp="False" CenterX="0.0" CenterY="0.0" DataSetType="Sky" ElevationModel="False" FileType=".png" Generic="False" MeanRadius="1.0" Name="All-sky photo of the night sky" OffsetX="0.0" OffsetY="0.0" Projection="Toast" QuadTreeMap="0123" ReferenceFrame="Sky" Rotation="0.0" Sparse="True" StockSet="False" TileLevels="12" Url="https://cdn.worldwidetelescope.org/wwtweb/nlasdss.aspx?Q={1},{2},{3}" WidthFactor="1">
+    <Credits>NOIRLab/NSF/AURA/E. Slawik/M. Zamani</Credits>
+    <CreditsUrl>https://webbtelescope.org/contents/news-releases/2022/news-2022-031</CreditsUrl>
+    <Description>This is the largest open-source, freely available all-sky photo of the night sky. With 40,000 pixels, this is arguably one of the best such images ever made. The colossal sky-scape was compiled using images taken by astrophotographer Eckhard Slawik from the best and darkest locations around the globe: Germany (Waldenburg), Spain (Tenerife, La Palma), Namibia and Chile. An annotated version can be found at https://noirlab.edu/public/images/noirlab2430a/.</Description>
+    <ThumbnailUrl></ThumbnailUrl>
+  </ImageSet>
+</Folder>

--- a/src/RubinFirstLight.vue
+++ b/src/RubinFirstLight.vue
@@ -303,11 +303,26 @@ onMounted(() => {
     // If there are layers to set up, do that here!
     layersLoaded.value = true;
 
+    // We'll probably end up changing the WTML setup once we have the final images anyways
+    // so not worth trying to make this super-clean now
     store.loadImageCollection({
       url: wtmlUrl,
       loadChildFolders: false,
     }).then(resultFolder => {
       folder.value = resultFolder; 
+    });
+
+    store.loadImageCollection({
+      url: "bg.wtml",
+      loadChildFolders: false,
+    }).then(folder => {
+      const children = folder.get_children();
+      if (children !== null) {
+        const item = children[0];
+        if (item instanceof Imageset) {
+          store.setBackgroundImageByName(item.get_name());
+        }
+      }
     });
 
   });


### PR DESCRIPTION
As the title says, this PR updates the interactive background imageset to the NOIRLab All-Sky/DSS hybrid map. The WTML for this is local to the repository (in the `public` directory so that it's exposed as `<root domain>/bg.wtml`.