### PR TITLE
Change repository owner to look for in workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: ${{ github.repository_owner == 'cosmicds' }}
+    if: ${{ github.repository_owner == 'wwt-ambassadors' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The workflow files here were borrowed from the setup that we use in CosmicDS, but I forgot to change the owner to look for in the deployment workflow. This PR fixes that.