### PR TITLE
Minor fixes for wwt tracked content

### DIFF
--- a/src/RubinFirstLook.vue
+++ b/src/RubinFirstLook.vue
@@ -394,7 +394,7 @@ onMounted(() => {
 
     // If there are layers to set up, do that here!
     layersLoaded.value = true;
-
+    
     // We'll probably end up changing the WTML setup once we have the final images anyways
     // so not worth trying to make this super-clean now
     store.loadImageCollection({
@@ -947,16 +947,18 @@ video {
 
 .tracked-element:hover {
   scale: 1.2;
+  z-index: 10;
 }
 
 .tracked-places {
-  width: auto;
+  width: max-content;
   padding: 0.5em;
   color: white;
   background-color: rgba(0, 0, 0, 0.51);
   backdrop-filter: blur(5px);
   border-radius: 5px;
-  // transform: translate(-50%, 50%); // center on the point
+  // transform: translate(-50%, -50%); // center on the point
+  position: absolute;
 }
 
 #controls-row {

--- a/src/components/WWTTrackedContent.vue
+++ b/src/components/WWTTrackedContent.vue
@@ -57,11 +57,12 @@ const zoomDeg = computed(() => {
 
 if (props.place) {
   const iset = props.place.get_backgroundImageset() ?? props.place.get_studyImageset();
+  
   if (iset === null) {
     console.warn(`Place ${props.place.get_name()} does not have a background or study imageset.`);
   } else {
-    ra.value = iset.get_centerX();
-    dec.value = iset.get_centerY();
+    ra.value = (props.place.get_RA() as HourAngle) * 15 as Degree;
+    dec.value = props.place.get_dec();
     name.value = iset.get_name();
   }
 }
@@ -166,7 +167,7 @@ const slots = defineSlots<{
     >
     <slot :on="{'click': onClick, 'keydown.enter': onClick}" >
       <div 
-        class="default-wwt-tracked-content-content allow-pointer" 
+        :class="['default-wwt-tracked-content-content', { debug: debug }]" 
         @click="onClick" 
         @keydown.enter="onClick"
       >
@@ -184,6 +185,10 @@ const slots = defineSlots<{
   cursor: pointer;
 }
 
+.wwt-tracked-content.debug {
+  outline: 1px solid red;
+}
+
 .default-wwt-tracked-content-content {
   width: 100px;
   height: 100px;
@@ -192,11 +197,14 @@ const slots = defineSlots<{
 }
 
 .tracking-debug-circle {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 10px;
   height: 10px;
   border-radius: 50%;
   background-color: red;
-  transform: translate(-50%, -50%);
+  // transform: translate(-50%, -50%);
 }
 
 </style>


### PR DESCRIPTION
This fixes two bugs with the positioning of the tracked markers
 1. Use the Place ra/dec instead of the imageset RA/DEC (otherwise everything will overlap)
 2. Fix position of the debug point so that it is at the correct corner & by default have the tracked markers top-left corner marker the coordinate position