### PR TITLE
Hide 'Go to Image A/B' button in fullscreen mode

### DIFF
--- a/src/RubinFirstLook.vue
+++ b/src/RubinFirstLook.vue
@@ -100,7 +100,7 @@
       </div>
       <div id="right-buttons">
         <div
-          v-hide="fullscreen"
+          v-if="!fullscreen"
           :class="[{'go-to-a': mode == 'b', 'go-to-b': mode == 'a'}]"
           id="goto-other-image"
           @click="gotoMainImage((mode == 'a') ? 'b' : 'a', false)"
@@ -108,7 +108,7 @@
         >
           Go to Image {{ mode == 'a' ? 'B' : 'A' }}
         </div>
-        <div v-hide="fullscreen">
+        <div v-if="!fullscreen">
           <icon-button
             id="info-icon"
             v-model="showTextSheet"
@@ -119,7 +119,7 @@
           >
           </icon-button>
         </div>
-        <div v-hide="fullscreen">
+        <div v-if="!fullscreen">
           <icon-button
             v-model="showVideoSheet"
             fa-icon="video"


### PR DESCRIPTION
The "Go to Image A/B" is currently visible in fullscreen mode - this PR hides it.