### PR TITLE
Fix issue with closest place determination

### DIFF
--- a/src/RubinFirstLook.vue
+++ b/src/RubinFirstLook.vue
@@ -678,7 +678,6 @@ function findClosest(places: Place[]): Place | null {
 
   places.forEach(place => {
     const dist = distanceFromCenter(place);
-    console.log(place.get_name(), dist);
     if ((!isNaN(dist)) && ((closestDist === null) || (dist < closestDist))) {
       closest = place;
       closestDist = dist;


### PR DESCRIPTION
This PR fixes #48. The problem was that we were determining the closest place by the imageset, but all of our places are connected to the same imageset so this wasn't helpful. This updates our calculation to use the place locations instead.