### PR TITLE
Small functionality tweaks

### DIFF
--- a/src/RubinFirstLook.vue
+++ b/src/RubinFirstLook.vue
@@ -77,6 +77,7 @@
           :text-color="textColor"
           flex-direction="column"
           @select="({ item, type }) => handleSelection(item, type)"
+          :start-expanded="!smallSize"
         >
           <template #header="{ toggleExpanded, expanded }">
             <div class="fv-header">
@@ -1431,6 +1432,7 @@ video {
 .fv-header {
   font-size: 11pt;
   font-weight: bold;
+  min-width: 96px;
 
   svg {
     padding: 0px 5px;

--- a/src/components/FolderView.vue
+++ b/src/components/FolderView.vue
@@ -57,13 +57,14 @@ const props = withDefaults(defineProps<FolderViewProps>(), {
   thumbnailColor: "white",
   backgroundColor: "black",
   textColor: "white",
+  startExpanded: true,
 });
 
 const emit = defineEmits<{
   (event: "select", data: { item: Thumbnail, type: ItemSelectionType }): void;
 }>();
 
-const expanded = ref(true);
+const expanded = ref(props.startExpanded);
 function toggleExpanded() {
   expanded.value = !expanded.value;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface FolderViewProps {
   thumbnailColor?: string;
   highlightColor?: string;
   textColor?: string;
+  startExpanded?: boolean;
 }
 
 export type ItemSelectionType = "click" | "dblclick" | "keyup" | "folder";


### PR DESCRIPTION
- For now, don't display circle on marker hover since it is behaving sluggishly/flakily on my computer. We can check again after deployment in case having the images served from the WWT servers instead of locally makes a difference in the behavior.
- Make zoom_cutoff match small labels cutoff. (This is to avoid some weird behaviors where for large objects that are displayed with a far out zoom level, the circles do not appear on click).
- Last few behavioral updates