### PR TITLE
Use same styling for opacity slider checkbox

### DIFF
--- a/src/RubinFirstLook.vue
+++ b/src/RubinFirstLook.vue
@@ -200,7 +200,7 @@
               v-if="!smallSize"
               v-model="showSlider"
               label="Opacity Slider"
-              :color="accentColor"
+              :color="buttonColor"
               hide-details
               density="compact"
             ></v-checkbox>


### PR DESCRIPTION
Update the opacity slider checkbox to use the same styling as the rest of the checkboxes.